### PR TITLE
Snippet added: configure default site creation, and provide better default domain (localhost:8000)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,3 +34,6 @@ Maintained By
 --------------------
 #. stringify
 
+2536. Configurable defaults for contrib.sites default Site during syncdb
+------------------------------------------------------------------------
+#. chrischambers

--- a/README.rst
+++ b/README.rst
@@ -103,3 +103,19 @@ Example::
     >>> from django.core import serializers
     >>> csvdata = serializers.serialize('csv', Foo.objects.all())
 
+2536. Configurable defaults for contrib.sites default Site during syncdb
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Modelled after #1875, this provides a more sensible default for the ``Site``
+object created during the first pass of ``syncdb`` (default domain of
+``localhost:8000``). It means that the admin's "view on site" button will work
+automagically, amongst other things.
+
+Original Snippet - http://djangosnippets.org/snippets/2536/
+
+To enable, simply add ``snippetscream`` to your ``INSTALLED_APPS`` settings.
+If you'd like to customise the default ``Site`` yourself, you can specify:
+
+* settings parameters (``DEFAULT_SITE_DOMAIN`` and ``DEFAULT_SITE_NAME``) or
+* ``kwargs`` for the ``create_default_site`` function [#]_
+
+.. [#] ``kwargs`` take precedence over the settings parameters.

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,4 @@
 from setuptools import setup, find_packages
-from setuptools.command.test import test
-
-def run_tests(self):
-    from setuptest.runtests import runtests
-    return runtests(self)
-test.run_tests = run_tests
 
 setup(
     name='django-snippetscream',
@@ -16,9 +10,9 @@ setup(
     url='http://github.com/shaunsephton/django-snippetscream',
     packages=find_packages(),
     include_package_data=True,
-    test_suite="snippetscream.tests",
+    test_suite="setuptest.SetupTestSuite",
     tests_require=[
-        'django-setuptest',
+        'django-setuptest>=0.0.6',
     ],
     classifiers = [
         "Programming Language :: Python",

--- a/snippetscream/_2536.py
+++ b/snippetscream/_2536.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+# Adapted From Http://stackoverflow.com/questions/1466827/ --
+from django.conf import settings
+from django.db.models import signals
+from django.contrib.sites.models import Site
+from django.contrib.sites import models as site_app
+from django.contrib.sites.management import create_default_site as orig_default_site
+
+signals.post_syncdb.disconnect(orig_default_site, sender=site_app)
+
+# Configure default Site creation with better defaults, and provide
+# overrides for those defaults via settings and kwargs:
+def create_default_site(app, created_models, verbosity, db, **kwargs):
+    name  = kwargs.pop('name', None)
+    domain = kwargs.pop('domain', None)
+
+    if not name:
+        name = getattr(settings, 'DEFAULT_SITE_NAME', 'example.com')
+    if not domain:
+        domain = getattr(settings, 'DEFAULT_SITE_DOMAIN', 'localhost:8000')
+
+    if Site in created_models:
+        if verbosity >= 2:
+            print "Creating example.com Site object"
+        s = Site(domain=domain, name=name)
+        s.save(using=db)
+    Site.objects.clear_cache()
+
+signals.post_syncdb.connect(create_default_site, sender=site_app)

--- a/snippetscream/__init__.py
+++ b/snippetscream/__init__.py
@@ -3,3 +3,4 @@ from _963 import *
 from _1031 import *
 from _1378 import *
 import _1875
+import _2536


### PR DESCRIPTION
See description at: http://djangosnippets.org/snippets/2536/
