### PR TITLE
pk None can get a new one at save, cause ORM to insert a new row.

### DIFF
--- a/snippetscream/_2240.py
+++ b/snippetscream/_2240.py
@@ -161,7 +161,7 @@ def Deserializer(stream_or_string, **options):
             # would be better?
             header = row
             continue
-        d = dict(zip(header[:2], row[:2]))
+        d = dict(zip(header[:2], map(lambda item: item != 'NULL' and item or None ,row[:2])))
         d['fields'] = dict(zip(header[2:], map(process_item, row[2:])))
         data.append(d)
 


### PR DESCRIPTION
map pk NULL to None make python.Deserializer working with pk:None to insert new row
